### PR TITLE
DOCSP-1115: Upgrade mut-publish to use boto3, and refactor

### DIFF
--- a/mut/__init__.py
+++ b/mut/__init__.py
@@ -1,6 +1,6 @@
 import abc
 
-__version__ = '0.3.dev0'
+__version__ = '0.4.dev0'
 
 
 class MutInputError(Exception, metaclass=abc.ABCMeta):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from setuptools import setup, find_packages
 import mut
 
 REQUIRES = [
-    'boto',
     'boto3',
     'certifi',
     'cssselect',


### PR DESCRIPTION
* Upgrades to `boto3` for S3 interaction.
* Drops `--destage`. It's kind of a rare and dangerous action to take, and I'm not confident in it.
* Halves the number of deployment threads. 10 just seems excessive, and will likely over-saturate any network.
* Instead of applying actions haphazardly, they're now queued into a `ChangeSet` for easier inspection and summary.
* Drops the `Redirects` class. It was unnecessary.
* Drops the `BulletProofS3` class. It worked around boto2 issues.
* Replaces `get_file_collector()` methods with a simpler `Collection` class attribute.

I'm sure this isn't perfect, but this should be an important step forward in making deploys more reliable.