### PR TITLE
DOP-1560: apply Gatsby caching recommendations

### DIFF
--- a/mut/stage.py
+++ b/mut/stage.py
@@ -87,8 +87,12 @@ T = TypeVar('T')
 
 class CacheControl:
     """A manager for cache-control headers. When constructed it takes a list of stanzas,
-       each of the type Tuple[List[str], str]: this maps a set of shell-style wildcards
-       to a cache-control header. See the DEFAULT_PATTERN for an example.
+       each of the type Tuple[List[str], str]: this maps a set of wildcard patterns
+       to a cache-control header, following the Python fnmatch rules[1].
+
+       See the DEFAULT_PATTERN for an example.
+
+       [1]: https://docs.python.org/3/library/fnmatch.html
     """
     # Based on https://www.gatsbyjs.com/docs/caching/
     DEFAULT_PATTERN = '''[


### PR DESCRIPTION
See headers for the following:
* https://docs-mongodborg-staging.corp.mongodb.com/bi-connector/andrew.aldridge/v2.2/index.html
* https://docs.mongodb.com/meta/index.html
* https://docs.mongodb.com/bi-connector/meta/page-data/app-data.json
* https://docs.mongodb.com/bi-connector/meta/searchindex.js

For example, run:
```
for url in https://docs-mongodborg-staging.corp.mongodb.com/bi-connector/andrew.aldridge/v2.2/index.html https://docs.mongodb.com/meta/ https://docs.mongodb.com/meta/page-data/app-data.json https://docs.mongodb.com/meta/searchindex.js; do
  echo -n "$url    "
  curl -L -s -o /dev/null -D - "$url" | grep -i 'Cache-Control:'
done
```
and ensure that each URL's cache-control header looks correct.