### PR TITLE
DOP-1268: Propogate mut deletions to --json flag output

### DIFF
--- a/mut/stage.py
+++ b/mut/stage.py
@@ -226,7 +226,7 @@ class ChangeSet:
     def __init__(self, verbose: bool, deployed_url_prefix: str) -> None:
         self.verbose = verbose
         self.suspicious_files = []  # type: List[str]
-        self.full_deploy_urls = []  # type: List[Tuple[str, str]]
+        self.modified_full_urls = []  # type: List[Tuple[str, str]]
         self.deployed_url_prefix = deployed_url_prefix
 
         self.commands_delete = []  # type: List[Tuple[str, str]]
@@ -243,7 +243,7 @@ class ChangeSet:
         """Request deletion of a list of keys."""
         for key in keys:
             self.commands_delete.append((flag, key))
-            self.full_deploy_urls.append((flag, self.deployed_url_prefix + '/' + key))
+            self.modified_full_urls.append((flag, self.deployed_url_prefix + '/' + key))
 
     def delete_redirects(self, keys: List[str]) -> None:
         """Request deletion of a list of redirects. Behavior is the same as ChangeSet.delete():
@@ -259,7 +259,7 @@ class ChangeSet:
             self.suspicious_files.append(key)
 
         # full url with deploy prefix in a separate list from the list of files to actually upload
-        self.full_deploy_urls.append((flag, self.deployed_url_prefix + '/' + key))
+        self.modified_full_urls.append((flag, self.deployed_url_prefix + '/' + key))
 
         self.commands_upload.append((flag, path, key))
 
@@ -276,7 +276,7 @@ class ChangeSet:
         # convert full urls with deploy prefix to json
         if return_json:
             json_obj = {'urls': []}  # type: Dict[str, List[str]]
-            for command in self.full_deploy_urls:
+            for command in self.modified_full_urls:
                 flag, path = command
                 json_obj['urls'].append(path)
             print(json.dumps(json_obj))

--- a/mut/stage.py
+++ b/mut/stage.py
@@ -239,14 +239,16 @@ class ChangeSet:
 
         self.cache_control = CacheControl([])
 
-    def delete(self, objects: List[str], tag: str = 'D') -> None:
-        """Request deletion of a list of objects."""
-        self.commands_delete.extend((tag, x) for x in objects)
+    def delete(self, keys: List[str], flag: str = 'D') -> None:
+        """Request deletion of a list of keys."""
+        for key in keys:
+            self.commands_delete.append((flag, key))
+            self.full_deploy_urls.append((flag, self.deployed_url_prefix + '/' + key))
 
-    def delete_redirects(self, objects: List[str]) -> None:
+    def delete_redirects(self, keys: List[str]) -> None:
         """Request deletion of a list of redirects. Behavior is the same as ChangeSet.delete():
            the distinction is informational for ChangeSet.print()."""
-        self.delete(objects, tag='DR')
+        self.delete(keys, flag='DR')
 
     def upload(self, path: str, key: str, new_file: bool) -> None:
         """Upload a local path into the bucket. new_file is informational for ChangeSet.print()."""
@@ -606,7 +608,7 @@ class Staging:
     @property
     def namespace(self) -> str:
         """Staging places each stage under a unique namespace computed from an
-           arbitrary username and branch This helper returns such a
+           arbitrary username and branch. This helper returns such a
            namespace, appropriate for constructing a new Staging instance."""
         # The S3 prefix for this staging site
         return '/'.join([x for x in (self.config.prefix,


### PR DESCRIPTION
[[DOP-1268]](https://jira.mongodb.org/browse/DOP-1268).

A/C:
- add deleted files to the output for --json

Also:
- Renames instances of `flag`to `tag` for consistency
- Renames instances `objects` to `keys` for consistency
