### PR TITLE
mut-images: fix bitrot when invoking helpers

### DIFF
--- a/mut/build_images.py
+++ b/mut/build_images.py
@@ -54,13 +54,14 @@ def generate_svg(input_path: str, output_path: str) -> None:
 
     input_path = os.path.abspath(input_path)
     output_path = os.path.abspath(output_path)
-    with tempfile.NamedTemporaryFile() as tmp:
+    with tempfile.NamedTemporaryFile(suffix=".svg") as tmp:
         subprocess.check_call([inkscape,
                                input_path,
                                '--vacuum-defs',
                                '--export-text-to-path',
                                '--export-area-drawing',
-                               '--export-plain-svg', tmp.name],
+                               '--export-plain-svg',
+                               '-o', tmp.name],
                               stdout=subprocess.DEVNULL,
                               stderr=subprocess.DEVNULL)
 
@@ -68,8 +69,6 @@ def generate_svg(input_path: str, output_path: str) -> None:
                                '-q',
                                '--multipass',
                                '-p', '1',
-                               '--enable=removeTitle',
-                               '--enable=removeViewBox',
                                '-i', tmp.name,
                                '-o', output_path])
 


### PR DESCRIPTION
* Don't use command line flags that svgo has removed
* Pass -o to inkscape