### PR TITLE
make mut less picky

### DIFF
--- a/mut/index/utils/Logger.py
+++ b/mut/index/utils/Logger.py
@@ -18,4 +18,3 @@ def log_unsuccessful(action: str, message: str, exception) -> None:
         ])
         message = '\n'.join([message, exception])
     print(message)
-    sys.exit()

--- a/mut/stage.py
+++ b/mut/stage.py
@@ -811,7 +811,7 @@ def main() -> None:
         summary = staging.changes.print(return_json)
 
         if summary.suspicious:
-            (prompt, confirmation) = (util.color('Commit? (YES/n): ', ('red', 'bright')), 'YES')
+            (prompt, confirmation) = (util.color('Commit? (y/n): ', ('red', 'bright')), 'y')
         else:
             (prompt, confirmation) = ('Commit? (y/n): ', 'y')
 


### PR DESCRIPTION
* Deploy confirmation prompt when deleting a large number of files is now the same
* Do not abort on mut-index parse issues