### PR TITLE
DOP-4086: mut-redirects: Warn on redirects with invalid redirect targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         architecture: 'x64'
     - name: Setup poetry
       run: python3 -m pip install poetry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-20.04, macos-latest]
-        python-version: ['3.8', '3.12']
+        python-version: ['3.12']
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v3

--- a/mut/redirects/redirect_main.py
+++ b/mut/redirects/redirect_main.py
@@ -53,8 +53,12 @@ class RedirectContext:
         old_url_sub = self.rule_substitute(old_url, version)
         new_url_sub = self.rule_substitute(new_url, version)
 
+        # S3 redirects must either have an HTTP scheme *or* have an absolute path
         parsed_new_url = urllib.parse.urlparse(new_url_sub)
-        if parsed_new_url.scheme not in {"http", "https"}:
+        if parsed_new_url.scheme not in {
+            "http",
+            "https",
+        } and not parsed_new_url.path.startswith("/"):
             raise ValueError(
                 f"Redirect targets must be absolute HTTP URLs: '{new_url_sub}'"
             )

--- a/mut/redirects/redirect_main.py
+++ b/mut/redirects/redirect_main.py
@@ -60,7 +60,7 @@ class RedirectContext:
             "https",
         } and not parsed_new_url.path.startswith("/"):
             raise ValueError(
-                f"Redirect targets must be absolute HTTP URLs: '{new_url_sub}'"
+                f"Invalid redirect target: '{new_url_sub}'. Redirect targets must be absolute HTTP URLs."
             )
 
         # reformatting the old url


### PR DESCRIPTION
Also return exit code 1 if there is an invalid redirect.

```
⬢[heli@toolbox mut]$ poetry run mut-redirects ../../redirects
55: Redirect targets must be absolute HTTP URLs: 'languages/installation/'
```