### PR TITLE
netlify-redirects-hotfix add new flag to yaml file

### DIFF
--- a/doc/source/includes/options-mut-publish.yaml
+++ b/doc/source/includes/options-mut-publish.yaml
@@ -89,4 +89,12 @@ inherit:
   name: verbose
   program: _shared
   file: options-shared.yaml
+---
+program: mut-publish
+name: force-sync-redirects
+directive: option
+description: |
+  Force redirects to sync with S3 regardless of current branch
+optional: true
+default: false
 ...

--- a/doc/source/reference/mut-publish.txt
+++ b/doc/source/reference/mut-publish.txt
@@ -20,6 +20,7 @@ Usage
                       [--redirects=htaccess]
                       [--redirect-prefix=prefix]...
                       [--dry-run] [--verbose]
+                      [--force-sync-redirects]
 
 Options
 -------
@@ -35,3 +36,4 @@ Options
 .. include:: /includes/option/option-mut-publish-redirect-prefixes.rst
 .. include:: /includes/option/option-mut-publish-dry-run.rst
 .. include:: /includes/option/option-mut-publish-verbose.rst
+.. include:: /includes/option/option-mut-publish-force-sync-redirects.rst

--- a/mut/stage.py
+++ b/mut/stage.py
@@ -19,6 +19,7 @@
                       [--deployed-url-prefix=prefix]
                       [--redirect-prefix=prefix]...
                       [--dry-run] [--verbose] [--json]
+                      [--force-sync-redirects]
 mut-publish --version
 
 -h --help                       show this help message
@@ -877,7 +878,7 @@ def main() -> None:
         logger.error("Error compiling regular expression: %s", str(err))
         sys.exit(1)
 
-    logger.info("Config:", config)
+    logger.info("Config:", vars(config))
 
     if mode_stage:
         staging = Staging(config)


### PR DESCRIPTION
### CONTEXT

Follow up for [earlier PR](https://github.com/mongodb/mut/pull/78)

Redirects have not been uploading to S3 on Netlify builds and these PRs attempt to address this.
This PR adds the force_sync_redirects flag to the mut-publish program in yml.


 ### [DOP-5355](https://jira.mongodb.org/browse/DOP-5355)