### PR TITLE
Add macos-13, macos-latest to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        platform: [ubuntu-20.04]
+        platform: [ubuntu-22.04, macos-13, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Build for macos (and update ubunto version) - copied from  https://github.com/mongodb/snooty-parser/blob/main/.github/workflows/release.yml