### PR TITLE
DOP-5546: update ubuntu v22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        platform: [ubuntu-20.04]
+        platform: [ubuntu-22.04]
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        platform: [ubuntu-20.04, macos-latest]
+        platform: [ubuntu-22.04, macos-latest]
         python-version: ['3.12']
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
     - main
     - 'v[0-9]*'
   pull_request:
+    branches:
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
Updates ubuntu to v22 since [v20 will be deprecated](https://github.com/actions/runner-images/issues/11101)